### PR TITLE
예산 관련 카테고리 enum 추가

### DIFF
--- a/src/main/java/com/wanted/domain/category/cost/constants/CategoryName.java
+++ b/src/main/java/com/wanted/domain/category/cost/constants/CategoryName.java
@@ -1,0 +1,15 @@
+package com.wanted.domain.category.cost.constants;
+
+public enum CategoryName {
+    Food,
+    Transportation,
+    Cultural,
+    GroceryShopping,
+    Fashion,
+    Housing,
+    Phone,
+    Healthcare,
+    Education,
+    Etc
+
+}

--- a/src/main/java/com/wanted/domain/category/cost/entity/CostCategory.java
+++ b/src/main/java/com/wanted/domain/category/cost/entity/CostCategory.java
@@ -1,12 +1,9 @@
 package com.wanted.domain.category.cost.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.wanted.domain.category.cost.constants.CategoryName;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,6 +23,13 @@ public class CostCategory {
     private Long id;
 
     // 카테고리 이름
+    @Enumerated(EnumType.STRING)
     @Column(name = "name", nullable = false)
-    private String name;
+    private CategoryName name;
+
+    @Builder
+    private CostCategory(Long id, CategoryName name) {
+        this.id = id;
+        this.name = name;
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #10 

## 📝 Description

카테고리는 정해진 항목이기 때문에 enum으로 관리하고자 추가했습니다.

## ⭐️ Review

이전 브런치 작업 때 진행해야 했는데 DB에 삽입할 까 하다가 좀 더 직관적으로 관리하고자 enum을 추가했습니다.
