### PR TITLE
Feature/#15 카테고리 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wanted/domain/category/cost/api/CostCategoryController.java
+++ b/src/main/java/com/wanted/domain/category/cost/api/CostCategoryController.java
@@ -1,0 +1,25 @@
+package com.wanted.domain.category.cost.api;
+
+import com.wanted.domain.category.cost.constants.CategoryName;
+import com.wanted.global.format.response.ResponseApi;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/cost-categories")
+public class CostCategoryController {
+    /**
+     * 모든 비용 카테고리 목록을 조회한다.
+     *
+     * @return 전체 카테고리 목록
+     */
+    @GetMapping
+    public ResponseEntity<ResponseApi> getCostCategories() {
+        List<CategoryName> categoryNames = List.of(CategoryName.values());
+        return ResponseEntity.ok(ResponseApi.toSuccessForm(categoryNames));
+    }
+}

--- a/src/test/java/com/wanted/domain/category/cost/api/CostCategoryControllerTest.java
+++ b/src/test/java/com/wanted/domain/category/cost/api/CostCategoryControllerTest.java
@@ -1,0 +1,34 @@
+package com.wanted.domain.category.cost.api;
+
+import com.wanted.budgetManagement.config.restdocs.AbstractRestDocsTests;
+import com.wanted.domain.category.cost.constants.CategoryName;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CostCategoryController.class)
+class CostCategoryControllerTest extends AbstractRestDocsTests {
+
+    private static final String COST_CATEGORY_URL = "/api/v1/cost-categories";
+
+    @Nested
+    @DisplayName("카테고리 전체 목록 조회")
+    class getBudgetCategories {
+        @Test
+        @DisplayName("카테고리 전체 목록 조회에 성공한다.")
+        void 카테고리_전체_목록_조회에_성공한다() throws Exception {
+            mockMvc.perform(get(COST_CATEGORY_URL)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(CategoryName.values().length));
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #15

## 📝 Description

카테고리 전체 목록을 조회하는 기능을 구현했습니다.
DB에서 불러오는 것 보단, 한단계라도 제거하기 위해 바로 Enum을 조회하는 방식으로 구현했습니다.

## ⭐️ Review